### PR TITLE
Revert "enable verbose logging on irrd call."

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -3,7 +3,7 @@ set -o errexit
 
 function run_tests {
     mkdir -p /tmp/irr/pgp_dir /tmp/irr/log
-    sudo irrd -v -f irrd.conf &
+    sudo irrd -f irrd.conf &
     sleep 2
     tests_round_1
     tests_with_pwhash_hiding


### PR DESCRIPTION
Reverts job/irrd#3

We do not need this option.
