### PR TITLE
remove the 'v' from the version number reported to clients

### DIFF
--- a/src/Make.include.in
+++ b/src/Make.include.in
@@ -2,7 +2,7 @@
 # $Id: Make.include.in,v 1.7 2001/12/03 20:07:33 ljb Exp $
 #
 
-GIT_VERSION = $(shell git describe --abbrev=4 --dirty --always --tags)
+GIT_VERSION = $(shell git describe --abbrev=4 --dirty --always --tags | sed 's/^v//')
 
 .c.o:
 #	@echo "Compiling:       $*.c"

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1,6 +1,6 @@
 # Process this file with autoconf to produce a configure script.
 
-AC_INIT([irrd], m4_esyscmd_s(echo $(git describe --abbrev=4 --dirty --always --tags )))
+AC_INIT([irrd], m4_esyscmd_s(echo $(git describe --abbrev=4 --dirty --always --tags | sed 's/^v//')))
 AM_INIT_AUTOMAKE([foreign])
 
 AC_PREREQ([2.59])


### PR DESCRIPTION
fixes issue #29 
