### PR TITLE
Pull fixes that are local to FreeBSD ports collection

### DIFF
--- a/src/programs/IRRd/database.c
+++ b/src/programs/IRRd/database.c
@@ -62,9 +62,11 @@ void database_clear (irr_database_t *db) {
 
   db->radix_v4 = New_Radix (32);
   db->radix_v6 = New_Radix (128);
-  fclose (db->db_fp);
 
-  db->db_fp = NULL;
+  if (db->db_fp) {
+    fclose (db->db_fp);
+    db->db_fp = NULL;
+  }
 }
 
 


### PR DESCRIPTION
* Fix re-close(3) problem.
* Add signal mask if already signaled.

These fixes were in FreeBSD port of IRRd for ages (at least from 2004).