### PR TITLE
Add -M to possible arguments for irr_rpsl_submit

### DIFF
--- a/src/programs/irr_rpsl_submit/main.c
+++ b/src/programs/irr_rpsl_submit/main.c
@@ -43,7 +43,7 @@ main(int argc, char *argv[])
   memset(&ci, 0, sizeof (config_info_t));
 
   /* Loop and process the command line flags */
-  while ((optval = getopt (argc, argv, "vc:NRDxtf:p:h:l:r:s:E:F:O:")) != -1)
+  while ((optval = getopt (argc, argv, "vc:MNRDxtf:p:h:l:r:s:E:F:O:")) != -1)
     switch (optval) {
     case 'c':
       if (*optarg == '-') {


### PR DESCRIPTION
Since MAIL-FROM as an auth method was deprecated, the irr_rpsl_submit -M
flag was added to re-enable MAIL-FROM, but was not added to the getopt
string.

This patch makes it possible to use that flag. Basic testing shows it to be effective.